### PR TITLE
Use window.zxcvbn_load_hook?() instead of zxcvbn_load_hook?() for the function definition check to prevent browser errors

### DIFF
--- a/init.coffee
+++ b/init.coffee
@@ -54,4 +54,4 @@ window.zxcvbn = (password, user_inputs) ->
   result.calc_time = time() - start
   result
 
-zxcvbn_load_hook?() # run load hook from user, if defined
+window.zxcvbn_load_hook?() # run load hook from user, if defined


### PR DESCRIPTION
Currently, the compiled.js file will throw a browser error if no `zxcvbn_load_hook` method is defined.

!['FireBug Screenshot'](http://content.screencast.com/users/croby/folders/Jing/media/3e814bb1-abee-495f-b742-4ce222e2bf9a/00000044.png)

The original coffeescript in init.coffee of

``` coffeescript
zxcvbn_load_hook?() # run load hook from user, if defined
```

compiles to

``` javascript
if (typeof zxcvbn_load_hook === "function") {
  zxcvbn_load_hook();
}
```

which, when zxcvbn_load_hook hasn't been defined, throws an error. This only happens when including compiled.js, before the minify step. A reproducible case is:

``` html
<html>
<body>
<script src="compiled.js"></script>
</body>
</html>
```

 I can't seem to reproduce this case outside of using the compiled.js code itself, as the minified version of above seems to somehow avoid this issue:

``` javascript
"function"===typeof zxcvbn_load_hook&&zxcvbn_load_hook()
```

This happens for me in Firefox 11.
