### PR TITLE
Fix for calc_bruteforce_cardinality

### DIFF
--- a/scoring.coffee
+++ b/scoring.coffee
@@ -234,9 +234,9 @@ calc_bruteforce_cardinality = (password) ->
     ord = chr.charCodeAt(0)
     if 0x30 <= ord <= 0x39
       digits = true
-    if 0x41 <= ord <= 0x5a
+    else if 0x41 <= ord <= 0x5a
       upper = true
-    if 0x61 <= ord <= 0x7a
+    else if 0x61 <= ord <= 0x7a
       lower = true
     else
       symbols = true


### PR DESCRIPTION
The function was overestimating the cardinality
for upper-case characters and digits by mistakenly
identifying them as symbols. Thus a simple repeat
sequence like "AAAAAA" would have cardinality
26+33=59 rather than 26.
