### PR TITLE
Export zxcvbn directly instead of as a property on exports

### DIFF
--- a/init.coffee
+++ b/init.coffee
@@ -60,4 +60,4 @@ if window?
   window.zxcvbn = zxcvbn
   window.zxcvbn_load_hook?() # run load hook from user, if defined
 else if exports?
-  exports.zxcvbn = zxcvbn
+  module.exports = zxcvbn


### PR DESCRIPTION
This way we can do:
var zxcvbn = require('zxcvbn');
zxcvbn(…);

instead of
var zxcvbn = require('zxcvbn').zxcvbn;
zxcvbn(…);