### PR TITLE
added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "zxcvbn",
+  "version": "1.0.0",
+  "main": "zxcvbn.js"
+}


### PR DESCRIPTION
I registered zxcvbn in the bower registry pointing to git://github.com/lowe/zxcvbn.git.  It will work as is, but would be more "correct" if you have this bower.json file in your repo, and tag your commits with semver version numbers.
