### PR TITLE
Guess URL for bootstrapping

### DIFF
--- a/async.coffee
+++ b/async.coffee
@@ -1,10 +1,26 @@
+# Fill this in if guessScriptPath isn't working for your configuration
+# Dropbox version ("http://dl.dropbox.com/u/209/zxcvbn/zxcvbn.js")
+# Should be autodetected if you are using the async script from
+# http://dl.dropbox.com/u/209/zxcvbn/zxcvbn-async.js
+ZXCVBN_SRC = null
 
-ZXCVBN_SRC = 'http://dl.dropbox.com/u/209/zxcvbn/zxcvbn.js'
+guessScriptPath = ->
+  scripts = document.getElementsByTagName 'SCRIPT'
+  path = ''
+  if scripts && scripts.length>0
+    for script in scripts
+      if script.src && script.src.match(/zxcvbn-async\.js(\?.*)?$/)
+        path = script.src.replace(/(.*)zxcvbn-async\.js(\?.*)?$/, '$1')
+  return path + "zxcvbn.js"
+
 
 # adapted from http://friendlybit.com/js/lazy-loading-asyncronous-javascript/
 async_load = ->
   s = document.createElement 'script'
-  s.src = ZXCVBN_SRC
+  if(ZXCVBN_SRC != null)
+    s.src = ZXCVBN_SRC
+  else
+    s.src = guessScriptPath()
   s.type = 'text/javascript'
   s.async = true
   first = document.getElementsByTagName('script')[0]


### PR DESCRIPTION
This pull request defaults the location of `zxcvbn.js` to be the same as `zxcvbn-async.js` -- if you just drop both files, unedited, into your assets directory, you won't accidentally be fetching the dropbox copy -- and it still "Just Works". On the other hand, if you "opt-in" to using CDN hosted authentication-related scripts (which, truth be told, is fine for a majority of sites) -- that "Just Works" too.

Before this patch, `zxcvbn-async.js` works out-of-box by setting up a hardcoded script tag pointing to a DropBox copy of `zxcvbn.js` (async.coffee, line 2)

This is great for the "Just Works" effect -- but that dropbox account becomes a single point of failure or compromise, for every site which forgets to or chooses not to reconfigure `zxcvbn-async.js`.

Your script is intended to improve security, and receives the user's credentials, and probably other privacy-sensitive information as well. Ideally, that sort of code should be served only via HTTPS from the authenticating site. IMHO, the default configuration shouldn't subvert that, though of course it should still be configurable to use CDN.
