### PR TITLE
Issue #20: use relative scheme-relative URL in async.coffee

### DIFF
--- a/async.coffee
+++ b/async.coffee
@@ -1,5 +1,5 @@
 
-ZXCVBN_SRC = 'http://dl.dropbox.com/u/209/zxcvbn/zxcvbn.js'
+ZXCVBN_SRC = '//dl.dropbox.com/u/209/zxcvbn/zxcvbn.js'
 
 # adapted from http://friendlybit.com/js/lazy-loading-asyncronous-javascript/
 async_load = ->


### PR DESCRIPTION
The previous fix by @gingerlime only changed the generated JS and gets
squashed whenever we recompile the CoffeeScript sources.
