### PR TITLE
Improve display of estimated time to crack password.

### DIFF
--- a/src/time_estimates.coffee
+++ b/src/time_estimates.coffee
@@ -42,9 +42,10 @@ time_estimates =
     year = month * 12
     century = year * 100
     [display_num, display_str] = if seconds < 1
-      [null, 'subsecond']
+      [null, 'less than a second']
     else if seconds < minute
-      [seconds, "#{seconds} second"]
+      base = Math.round seconds
+      [base, "#{base} second"]
     else if seconds < hour
       base = Math.round seconds / minute
       [base, "#{base} minute"]


### PR DESCRIPTION
* the estimates under a minute weren't rounded properly (e.g. "it will take approximately 3.000004 seconds to guess this password")
* changed the "subsecond" to make it fit with the other descriptors (cf. in the sentence above, "less than a second" fits better than "subsecond" to replace the time)