### PR TITLE
Temporarily link to the wayback machine 10k top passwords list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Add to your .html:
 ```
 
 # Usage
- 
+
 ``` javascript
 zxcvbn(password, user_inputs=[])
 ```
@@ -266,7 +266,7 @@ For node developers, in addition to `dist`, the zxcvbn `npm` module includes a `
 
 Leah Culver and Ryan Pearl for porting zxcvbn to [Objective C](https://github.com/dropbox/zxcvbn-ios) and [python](https://github.com/dropbox/python-zxcvbn).
 
-Mark Burnett for releasing his [10k top passwords list](http://xato.net/passwords/more-top-worst-passwords) and for his 2005 book, [Perfect Passwords: Selection, Protection, Authentication](http://www.amazon.com/Perfect-Passwords-Selection-Protection-Authentication/dp/1597490415).
+Mark Burnett for releasing his [10k top passwords list](https://web.archive.org/web/20140723034133/https://xato.net/passwords/more-top-worst-passwords/) and for his 2005 book, [Perfect Passwords: Selection, Protection, Authentication](http://www.amazon.com/Perfect-Passwords-Selection-Protection-Authentication/dp/1597490415).
 
 Wiktionary contributors for building a [frequency list of English](http://en.wiktionary.org/wiki/Wiktionary:Frequency_lists) as used in television and movies.
 


### PR DESCRIPTION
Hi, https://xato.net/ is down for "a major overhaul." I'm not sure how long it will be down, so this PR temporarily replaces the broken link to the 10k top passwords list with the wayback machine version.