### PR TITLE
Add angular-zxcvbn to the list of the library integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ At Dropbox we use zxcvbn ([Release notes](https://github.com/dropbox/zxcvbn/rele
 * [`zxcvbn-cs`](https://github.com/mickford/zxcvbn-cs) (C#/.NET)
 * [`szxcvbn`](https://github.com/tekul/szxcvbn) (Scala)
 
+Integrations with other frameworks:
+* [`angular-zxcvbn`](https://github.com/ghostbar/angular-zxcvbn) (AngularJS)
+
 For more motivation, see:
 
 http://tech.dropbox.com/?p=165
@@ -129,8 +132,7 @@ Download [zxcvbn.js](https://raw.githubusercontent.com/dropbox/zxcvbn/master/dis
 Add to your .html:
 
 ``` html
-<script type="text/javascript" src="path/to/zxcvbn.js">
-</script>
+<script type="text/javascript" src="path/to/zxcvbn.js"></script>
 ```
 
 # Usage


### PR DESCRIPTION
In order to make the library be used it would be important to sponsorize the valid integrations with relevant frameworks.

Here follows the AnguarJS integration.