### PR TITLE
Add `zxcvbn-js` ruby gem to language port list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ At Dropbox we use zxcvbn ([Release notes](https://github.com/dropbox/zxcvbn/rele
 * [`python-zxcvbn`](https://github.com/dropbox/python-zxcvbn) (Python)
 * [`zxcvbn-go`](https://github.com/nbutton23/zxcvbn-go) (Go)
 * [`zxcvbn-ruby`](https://github.com/envato/zxcvbn-ruby) (Ruby)
+* [`zxcvbn-js`](https://github.com/bitzesty/zxcvbn-js) (Ruby [via ExecJS])
 * [`zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (PHP)
 * [`zxcvbn-cs`](https://github.com/mickford/zxcvbn-cs) (C#/.NET)
 * [`szxcvbn`](https://github.com/tekul/szxcvbn) (Scala)


### PR DESCRIPTION
Add https://github.com/bitzesty/zxcvbn-js to port list. It's a ruby gem that runs the JS version of zxcvbn via ExecJS.