### PR TITLE
Remove codetheweb:zxcvbn port for Meteor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To pull in updates and bug fixes:
 bower update zxcvbn
 ```
 
-## Node / npm
+## Node / npm / MeteorJS
 
 zxcvbn works identically on the server.
 
@@ -72,11 +72,6 @@ $ npm install zxcvbn
 $ node
 > var zxcvbn = require('zxcvbn');
 > zxcvbn('Tr0ub4dour&3');
-```
-
-## Meteor (via [Atmosphere](https://atmospherejs.com/codetheweb/zxcvbn))
-``` shell
-meteor add codetheweb:zxcvbn
 ```
 
 ## RequireJS


### PR DESCRIPTION
I no longer maintain my port, and Meteor now supports using exactly the same install procedure as vanilla Node.
