### PR TITLE
Set base_matches to the correct base_analysis.sequence in repeat_match()

### DIFF
--- a/src/matching.coffee
+++ b/src/matching.coffee
@@ -331,7 +331,7 @@ matching =
         base_token
         @omnimatch base_token
       )
-      base_matches = base_analysis.match_sequence
+      base_matches = base_analysis.sequence
       base_guesses = base_analysis.guesses
       matches.push
         pattern: 'repeat'


### PR DESCRIPTION
The base_matches in the repeat matcher results gets set to the non-existent base_analysis.match_sequence. This uses the correct base_analysis.sequence.