### PR TITLE
build_keyboard_adjacency_graphs.py: Support QWERTZ

### DIFF
--- a/data-scripts/build_keyboard_adjacency_graphs.py
+++ b/data-scripts/build_keyboard_adjacency_graphs.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python
+# coding=utf-8
 import sys
 import simplejson
 
 def usage():
     return '''
-constructs adjacency_graphs.coffee from QWERTY and DVORAK keyboard layouts
+constructs adjacency_graphs.coffee from QWERTY, QWERTZ and DVORAK keyboard layouts
 
 usage:
 %s adjacency_graphs.coffee
@@ -15,6 +16,13 @@ qwerty = r'''
     qQ wW eE rR tT yY uU iI oO pP [{ ]} \|
      aA sS dD fF gG hH jJ kK lL ;: '"
       zZ xX cC vV bB nN mM ,< .> /?
+'''
+
+qwertz = r'''
+^° 1! 2" 3§ 4$ 5% 6& 7/ 8( 9) 0= ß? ´`
+    qQ wW eE rR tT zZ uU iI oO pP üÜ +*
+     aA sS dD fF gG hH jJ kK lL öÖ äÄ #'
+   <> yY xX cC vV bB nN mM ,; .: -_
 '''
 
 dvorak = r'''
@@ -64,6 +72,7 @@ def build_graph(layout_str, slanted):
     * on keypad layout, '7' maps to [None, None, None, '=', '8', '5', '4', None]
     '''
     position_table = {} # maps from tuple (x,y) -> characters at that position.
+    layout_str = layout_str.decode('utf-8')
     tokens = layout_str.split()
     token_size = len(tokens[0])
     x_unit = token_size + 1 # x position unit len is token len plus 1 for the following whitespace.
@@ -98,6 +107,7 @@ if __name__ == '__main__':
         f.write('adjacency_graphs = \n  ')
         lines = []
         for graph_name, args in [('qwerty', (qwerty, True)),
+                                 ('qwertz', (qwertz, True)),
                                  ('dvorak', (dvorak, True)),
                                  ('keypad', (keypad, False)),
                                  ('mac_keypad', (mac_keypad, False))]:


### PR DESCRIPTION
This change proposes adjacency graph support for (german) QWERTZ keyboards.
