### PR TITLE
Improve meta files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ bower install zxcvbn
 Add this script to your `index.html`:
 
 ``` html
-<script type="text/javascript" src="bower_components/zxcvbn/dist/zxcvbn.js">
+<script src="bower_components/zxcvbn/dist/zxcvbn.js">
 </script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "author": "Dan Wheeler",
   "license": "MIT",
   "main": "lib/main.js",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/dropbox/zxcvbn.git"
-  },
+  "repository": "dropbox/zxcvbn",
   "scripts": {
     "test": "coffeetape test/*.coffee | faucet",
     "test-saucelabs": "zuul -- test/*.coffee",


### PR DESCRIPTION
- Needless script type attribute removed, as `"text/javascript"` is default script type in HTML5
- Repository property in `package.json` simplified, per [npm documentation](https://docs.npmjs.com/files/package.json#repository)

:snowflake: