### PR TITLE
Add link to Perl 5 port of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ At Dropbox we use zxcvbn ([Release notes](https://github.com/dropbox/zxcvbn/rele
 * [`zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (PHP)
 * [`zxcvbn-api`](https://github.com/wcjr/zxcvbn-api) (REST)
 * [`ocaml-zxcvbn`](https://github.com/cryptosense/ocaml-zxcvbn) (OCaml bindings for `zxcvbn-c`)
+* [`Data::Password::zxcvbn`](https://metacpan.org/pod/Data::Password::zxcvbn) (Perl 5)
 
 Integrations with other frameworks:
 * [`angular-zxcvbn`](https://github.com/ghostbar/angular-zxcvbn) (AngularJS)


### PR DESCRIPTION
The Perl 5 port was started by Gianni Ceccarelli late 2017 and was released last month (January 2018).

I am linking to the CPAN entry of the Perl module instead of the Git repository, which is hosted on Bitbucket, not GitHub.