### PR TITLE
Strip non-letters before calculating multiplier

### DIFF
--- a/src/scoring.coffee
+++ b/src/scoring.coffee
@@ -326,7 +326,8 @@ scoring =
   ALL_LOWER: /^[^A-Z]+$/
 
   uppercase_variations: (match) ->
-    word = match.token
+    # non-letters should be stripped before we do this calculation
+    word = match.token.replace /[^A-Za-z]/gi, ''
     return 1 if word.match(@ALL_LOWER) or word.toLowerCase() == word
     # a capitalized word is the most common capitalization scheme,
     # so it only doubles the search space (uncapitalized + capitalized).


### PR DESCRIPTION
The fix discussed in #232. Far more detail given over there, but briefly we need to strip non-letter characters to prevent single-token partitions with non-letters at the beginning or end from being over-rewarded for certain capitalization schemes. See issue #232  for (far) more detail.