### PR TITLE
Point to forked zxcvbn-php library that matches the JS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ At Dropbox we use zxcvbn ([Release notes](https://github.com/dropbox/zxcvbn/rele
 * [`zxcvbn-ios`](https://github.com/dropbox/zxcvbn-ios) (Objective-C)
 * [`zxcvbn-cs`](https://github.com/mickford/zxcvbn-cs) (C#/.NET)
 * [`szxcvbn`](https://github.com/tekul/szxcvbn) (Scala)
+* [`zxcvbn-php`](https://github.com/mkopinsky/zxcvbn-php) (PHP with scores matching the JS library)
 * [`zxcvbn-php`](https://github.com/bjeavons/zxcvbn-php) (PHP)
 * [`zxcvbn-api`](https://github.com/wcjr/zxcvbn-api) (REST)
 * [`ocaml-zxcvbn`](https://github.com/cryptosense/ocaml-zxcvbn) (OCaml bindings for `zxcvbn-c`)


### PR DESCRIPTION
The original zxcvbn-php library scores didn't match the JS libary, making it a pain to use both libraries together.
It was forked to mkopinsky/zxcvbn-php and the work was done to bring it inline with the JS library. @bjeavons says his library was inspired by the original, and wasn't to be an exact match (https://github.com/bjeavons/zxcvbn-php/issues/15#issuecomment-377952148)

While listing 2 PHP libraries may be a little confusing, it would be beneficial for those looking for an exact matching library to be able to find it from this readme.