### PR TITLE
Bug: Standardize punctuation for feedback messages.

### DIFF
--- a/src/feedback.coffee
+++ b/src/feedback.coffee
@@ -4,8 +4,8 @@ feedback =
   default_feedback:
     warning: ''
     suggestions: [
-      "Use a few words, avoid common phrases"
-      "No need for symbols, digits, or uppercase letters"
+      "Use a few words, avoid common phrases."
+      "No need for symbols, digits, or uppercase letters."
     ]
 
   get_feedback: (score, sequence) ->
@@ -40,77 +40,77 @@ feedback =
       when 'spatial'
         layout = match.graph.toUpperCase()
         warning = if match.turns == 1
-          'Straight rows of keys are easy to guess'
+          'Straight rows of keys are easy to guess.'
         else
-          'Short keyboard patterns are easy to guess'
+          'Short keyboard patterns are easy to guess.'
         warning: warning
         suggestions: [
-          'Use a longer keyboard pattern with more turns'
+          'Use a longer keyboard pattern with more turns.'
         ]
 
       when 'repeat'
         warning = if match.base_token.length == 1
-          'Repeats like "aaa" are easy to guess'
+          'Repeats like "aaa" are easy to guess.'
         else
-          'Repeats like "abcabcabc" are only slightly harder to guess than "abc"'
+          'Repeats like "abcabcabc" are only slightly harder to guess than "abc".'
         warning: warning
         suggestions: [
-          'Avoid repeated words and characters'
+          'Avoid repeated words and characters.'
         ]
 
       when 'sequence'
-        warning: "Sequences like abc or 6543 are easy to guess"
+        warning: "Sequences like abc or 6543 are easy to guess."
         suggestions: [
-          'Avoid sequences'
+          'Avoid sequences.'
         ]
 
       when 'regex'
         if match.regex_name == 'recent_year'
-          warning: "Recent years are easy to guess"
+          warning: "Recent years are easy to guess."
           suggestions: [
-            'Avoid recent years'
-            'Avoid years that are associated with you'
+            'Avoid recent years.'
+            'Avoid years that are associated with you.'
           ]
 
       when 'date'
-        warning: "Dates are often easy to guess"
+        warning: "Dates are often easy to guess."
         suggestions: [
-          'Avoid dates and years that are associated with you'
+          'Avoid dates and years that are associated with you.'
         ]
 
   get_dictionary_match_feedback: (match, is_sole_match) ->
     warning = if match.dictionary_name == 'passwords'
       if is_sole_match and not match.l33t and not match.reversed
         if match.rank <= 10
-          'This is a top-10 common password'
+          'This is a top-10 common password.'
         else if match.rank <= 100
-          'This is a top-100 common password'
+          'This is a top-100 common password.'
         else
-          'This is a very common password'
+          'This is a very common password.'
       else if match.guesses_log10 <= 4
-        'This is similar to a commonly used password'
+        'This is similar to a commonly used password.'
     else if match.dictionary_name == 'english_wikipedia'
       if is_sole_match
-        'A word by itself is easy to guess'
+        'A word by itself is easy to guess.'
     else if match.dictionary_name in ['surnames', 'male_names', 'female_names']
       if is_sole_match
-        'Names and surnames by themselves are easy to guess'
+        'Names and surnames by themselves are easy to guess.'
       else
-        'Common names and surnames are easy to guess'
+        'Common names and surnames are easy to guess.'
     else
       ''
 
     suggestions = []
     word = match.token
     if word.match(scoring.START_UPPER)
-      suggestions.push "Capitalization doesn't help very much"
+      suggestions.push "Capitalization doesn't help very much."
     else if word.match(scoring.ALL_UPPER) and word.toLowerCase() != word
-      suggestions.push "All-uppercase is almost as easy to guess as all-lowercase"
+      suggestions.push "All-uppercase is almost as easy to guess as all-lowercase."
 
     if match.reversed and match.token.length >= 4
-      suggestions.push "Reversed words aren't much harder to guess"
+      suggestions.push "Reversed words aren't much harder to guess."
     if match.l33t
-      suggestions.push "Predictable substitutions like '@' instead of 'a' don't help very much"
+      suggestions.push "Predictable substitutions like '@' instead of 'a' don't help very much."
 
     result =
       warning: warning


### PR DESCRIPTION
Proposed MR for issue https://github.com/dropbox/zxcvbn/issues/248.

The feedback messages in feedback.coffee are not consistent with regards to punctuation. Some sentences are ended with a period, while others have no ending punctuation mark. This causes inconsistencies with implementing libraries such as https://github.com/antoantonyk/password-strength-meter.

![image](https://user-images.githubusercontent.com/3580801/52581476-da5a4880-2df8-11e9-9ae8-98e95c0badb0.png)
