### PR TITLE
Remove unused `layout` var in feedback

### DIFF
--- a/src/feedback.coffee
+++ b/src/feedback.coffee
@@ -38,7 +38,6 @@ feedback =
         @get_dictionary_match_feedback match, is_sole_match
 
       when 'spatial'
-        layout = match.graph.toUpperCase()
         warning = if match.turns == 1
           'Straight rows of keys are easy to guess'
         else


### PR DESCRIPTION
It appears to be entirely unused. Doing a git blame shows that it's been around for 4 years. Either it can be removed (as per this MR), or used somewhere?